### PR TITLE
Updated pom.xml and build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,6 @@ Arash Habibi Lashkari, Gerard Draper-Gil, Mohammad Saiful Islam Mamun and Ali A.
 Gerard Drapper Gil, Arash Habibi Lashkari, Mohammad Mamun, Ali A. Ghorbani, "Characterization of Encrypted and VPN Traffic Using Time-Related Features", In Proceedings of the 2nd International Conference on Information Systems Security and Privacy(ICISSP 2016) , pages 407-414, Rome , Italy
 
 # Development
-## Install jnetpcap local repo
-
-for linux, sudo is a prerequisite
-```
-//linux :at the pathtoproject/jnetpcap/linux/jnetpcap-1.4.r1425
-//windows: at the pathtoproject/jnetpcap/win/jnetpcap-1.4.r1425
-mvn install:install-file -Dfile=jnetpcap.jar -DgroupId=org.jnetpcap -DartifactId=jnetpcap -Dversion=1.4.1 -Dpackaging=jar
-```
 
 ## Run
 ### IntelliJ IDEA

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,12 @@ targetCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url "https://clojars.org/repo" }
 }
 dependencies {
     compile group: 'log4j', name: 'log4j', version:'1.2.17'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.25'
-    compile group: 'org.jnetpcap', name: 'jnetpcap', version:'1.4.1'
+    compile group: 'jnetpcap', name: 'jnetpcap', version:'1.4.r1425-1g'
     compile group: 'junit', name: 'junit', version:'4.12'
     compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.6'
     compile group: 'org.apache.commons', name: 'commons-math3', version:'3.5'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,12 @@
 	<artifactId>SimpleFlowMeterV3</artifactId>
 	<version>0.0.4-SNAPSHOT</version>
 	<name>SimpleFlowMeterV3</name>
-
+	<repositories>
+		<repository>
+		  <id>clojars.org</id>
+		  <url>https://repo.clojars.org</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>  
 		    <groupId>log4j</groupId>  
@@ -19,9 +24,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.jnetpcap</groupId>
-			<artifactId>jnetpcap</artifactId>
-			<version>1.4.1</version>
+		    <groupId>jnetpcap</groupId>
+		    <artifactId>jnetpcap</artifactId>
+		    <version>1.4.r1425-1g</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
No need to install newest version of jnetcap. This change prevents the first time error.