### PR TITLE
Fix count errors for Tot Fwd Pkts and Tot Bwd Pkts, update build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ repositories {
 dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.25'
-    compile group: 'org.jnetpcap', name: 'jnetpcap', version:'1.4.1'
+    // compile group: 'org.jnetpcap', name: 'jnetpcap', version:'1.4.1'
+	compile group: 'jnetpcap', name: 'jnetpcap', version: '1.4.r1425-1g'
     compile group: 'junit', name: 'junit', version:'4.12'
     compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.6'
     compile group: 'org.apache.commons', name: 'commons-math3', version:'3.5'

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,7 @@ repositories {
 dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.25'
-    // compile group: 'org.jnetpcap', name: 'jnetpcap', version:'1.4.1'
-	compile group: 'jnetpcap', name: 'jnetpcap', version: '1.4.r1425-1g'
+    compile group: 'jnetpcap', name: 'jnetpcap', version: '1.4.r1425-1g'
     compile group: 'junit', name: 'junit', version:'4.12'
     compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.6'
     compile group: 'org.apache.commons', name: 'commons-math3', version:'3.5'

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -128,8 +128,8 @@ public class BasicFlow {
 		if(this.dst==null){
 			this.dst = packet.getDst();
 			this.dstPort = packet.getDstPort();
-		}		
-		if(this.src == packet.getSrc()){
+		}
+		if(Arrays.equals(this.src, packet.getSrc())) {
 			this.min_seg_size_forward = packet.getHeaderBytes();
 			Init_Win_bytes_forward = packet.getTCPWindow();
 			this.flowLengthStats.addValue((double)packet.getPayloadBytes());

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -132,7 +132,6 @@ public class BasicFlow {
 		if(Arrays.equals(this.src, packet.getSrc())) {
 			this.min_seg_size_forward = packet.getHeaderBytes();
 			Init_Win_bytes_forward = packet.getTCPWindow();
-			this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 			this.fwdPktStats.addValue((double)packet.getPayloadBytes());
 			this.fHeaderBytes = packet.getHeaderBytes();
 			this.forwardLastSeen = packet.getTimeStamp();
@@ -146,7 +145,6 @@ public class BasicFlow {
 			}
 		}else{
 			Init_Win_bytes_backward = packet.getTCPWindow();
-			this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 			this.bwdPktStats.addValue((double)packet.getPayloadBytes());
 			this.bHeaderBytes = packet.getHeaderBytes();
 			this.backwardLastSeen = packet.getTimeStamp();
@@ -200,7 +198,6 @@ public class BasicFlow {
 				this.Act_data_pkt_forward++;
 			}
 			this.fwdPktStats.addValue((double)packet.getPayloadBytes());
-			this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 			this.fHeaderBytes +=packet.getHeaderBytes();
     		this.forward.add(packet);    		
     		this.forwardBytes+=packet.getPayloadBytes();


### PR DESCRIPTION
The code here：
https://github.com/ISCX/CICFlowMeter/blob/1d4e34eee43fd2e5fc37bf37dbae0558ca7c17fe/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java#L132

This will result in an error count for Tot Fwd Pkts and Tot Bwd Pkts.We can see: 
https://github.com/ISCX/CICFlowMeter/blob/1d4e34eee43fd2e5fc37bf37dbae0558ca7c17fe/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java#L38

https://github.com/ISCX/CICFlowMeter/blob/1d4e34eee43fd2e5fc37bf37dbae0558ca7c17fe/src/main/java/cic/cs/unb/ca/jnetpcap/BasicPacketInfo.java#L97

The byte[] type should be used Arrays.equals()，Should not be used `==`:
https://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html#equals-byte:A-byte:A-


In addition，Update the build.gradle file to solve the jnepcap version problem, reference:
https://github.com/ISCX/CICFlowMeter/issues/19#issuecomment-467331296