### PR TITLE
 Fix for generate csv in linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ $ gradle execute
 
 //windows:
 $ gradlew execute
+
+
+### For Linux: (x64)
+
+  Install libpcap-dev using:
+
+   1. $ sudo apt-get install libpcap-dev
+
+   2. Go to the jnetpcap folder inside CICFlowMeter/jnetpcap/linux/jnetpcap-1.4.r1425
+
+   3. Copy libjnetpcap.so and libjnetpcap-pcap100.so in /usr/lib/ (as sudo).
+
 ```
 ### Eclipse
 


### PR DESCRIPTION
We need to install libpcap-dev and copy libjnetpcap.so and libjnetpcap-pcap100.so inside the /use/lib/ . Else it doesn't generate CSV file.