### PR TITLE
fix bugs in BasicFlow.java and FlowGenerator.java

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -119,6 +119,14 @@ public class BasicFlow {
 	
 	
 	public void firstPacket(BasicPacketInfo packet){
+		if(this.src==null){
+			this.src = packet.getSrc();
+			this.srcPort = packet.getSrcPort();
+		}
+		if(this.dst==null){
+			this.dst = packet.getDst();
+			this.dstPort = packet.getDstPort();
+		}
 		updateFlowBulk(packet);
 		detectUpdateSubflows(packet);
 		checkFlags(packet);
@@ -128,14 +136,6 @@ public class BasicFlow {
 		this.endActiveTime = packet.getTimeStamp();
 		this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 
-		if(this.src==null){
-			this.src = packet.getSrc();
-			this.srcPort = packet.getSrcPort();
-		}
-		if(this.dst==null){
-			this.dst = packet.getDst();
-			this.dstPort = packet.getDstPort();
-		}		
 		if(Arrays.equals(this.src, packet.getSrc())){
 			this.min_seg_size_forward = packet.getHeaderBytes();
 			Init_Win_bytes_forward = packet.getTCPWindow();
@@ -391,7 +391,7 @@ public class BasicFlow {
 
 	public void updateFlowBulk (BasicPacketInfo packet){
 
-		if(this.src == packet.getSrc()){
+		if(Arrays.equals(this.src, packet.getSrc())){
 			updateForwardBulk(packet,blastBulkTS);
 		}else {
 			updateBackwardBulk(packet,flastBulkTS);

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -139,7 +139,6 @@ public class BasicFlow {
 		if(Arrays.equals(this.src, packet.getSrc())){
 			this.min_seg_size_forward = packet.getHeaderBytes();
 			Init_Win_bytes_forward = packet.getTCPWindow();
-			this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 			this.fwdPktStats.addValue((double)packet.getPayloadBytes());
 			this.fHeaderBytes = packet.getHeaderBytes();
 			this.forwardLastSeen = packet.getTimeStamp();
@@ -153,7 +152,6 @@ public class BasicFlow {
 			}
 		}else{
 			Init_Win_bytes_backward = packet.getTCPWindow();
-			this.flowLengthStats.addValue((double)packet.getPayloadBytes());
 			this.bwdPktStats.addValue((double)packet.getPayloadBytes());
 			this.bHeaderBytes = packet.getHeaderBytes();
 			this.backwardLastSeen = packet.getTimeStamp();

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -182,7 +182,13 @@ public class BasicFlow {
 				}
 				this.fwdPktStats.addValue((double)packet.getPayloadBytes());
 				this.fHeaderBytes +=packet.getHeaderBytes();
-    			this.forward.add(packet);   
+    			this.forward.add(packet);
+				if(packet.hasFlagPSH()){
+					this.fPSH_cnt++;
+				}
+				if(packet.hasFlagURG()){
+					this.fURG_cnt++;
+				}
     			this.forwardBytes+=packet.getPayloadBytes();
     			if (this.forward.size()>1)
     				this.forwardIAT.addValue(currentTimestamp -this.forwardLastSeen);
@@ -194,6 +200,12 @@ public class BasicFlow {
 				Init_Win_bytes_backward = packet.getTCPWindow();
 				this.bHeaderBytes+=packet.getHeaderBytes();
     			this.backward.add(packet);
+				if(packet.hasFlagPSH()){
+					this.bPSH_cnt++;
+				}
+				if(packet.hasFlagURG()){
+					this.bURG_cnt++;
+				}
     			this.backwardBytes+=packet.getPayloadBytes();
     			if (this.backward.size()>1)
     				this.backwardIAT.addValue(currentTimestamp-this.backwardLastSeen);

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
@@ -132,7 +132,7 @@ public class FlowGenerator {
     		    		// 1.- we add the packet-in-process to the flow (it is the last packet)
     		        	// 2.- we move the flow to finished flow list
     		        	// 3.- we eliminate the flow from the current flow list       					
-    					if ((flow.getBwdFINFlags() + flow.getBwdFINFlags()) == 2) {
+    					if ((flow.getFwdFINFlags() + flow.getBwdFINFlags()) == 2) {
     		    	    	logger.debug("FlagFIN current has {} flow",currentFlows.size());
     		    	    	flow.addPacket(packet);
     		                if (mListener != null) {
@@ -163,7 +163,7 @@ public class FlowGenerator {
     		    		// 1.- we add the packet-in-process to the flow (it is the last packet)
     		        	// 2.- we move the flow to finished flow list
     		        	// 3.- we eliminate the flow from the current flow list       					
-    					if ((flow.getBwdFINFlags() + flow.getBwdFINFlags()) == 2) {
+    					if ((flow.getFwdFINFlags() + flow.getBwdFINFlags()) == 2) {
     		    	    	logger.debug("FlagFIN current has {} flow",currentFlows.size());
     		    	    	flow.addPacket(packet);
     		                if (mListener != null) {


### PR DESCRIPTION
bug 1: BasicFlow.java
In BasicFlow.java:firstPacket, the variable flowLengthStats is added
by payload of packet twice rather than once.
The first time is after enter BasicFlow.java:firstPacket, and before
checking whether it is forward packet or backward packet.
The second time is after checking whether it is forward packet or
backward packet.

bug 2: BasicFlow.java
In the first packet of a flow which is handled in
BasicFlow.java:firstPacket, the flags PSH and URG are counted
correctly.
But in the second and after packets of a flow which is handled in
BasicFlow.java:addPacket, the flags PSH and URG are not counted
correctly.

but 3: BasicFlow.java
In the first packet of a flow which is handled in
BasicFlow.java:firstPacket, when calling function:updateFlowBulk, the
BasicFlow.src is null, but the BasicFlow.src is used to compare with
the source ip of the first packet.
In function:updateFlowBulk, in order to compare with BasicFlow.src
and the source ip of the first packet, the code use operator ==
rather than Arrays.equals.

bug 4: FlowGenerator.java
When handling a closed flow which receives FIN flag, the code from
FlowGenerator.java:addPacket check if the flow receive FIN flag on
both direction, but the code incorrectly use
function:getBwdFINFlags + function:getBwdFINFlags == 2
rather than
function:getFwdFINFlags + function:getBwdFINFlags == 2.